### PR TITLE
feat: add HTTP method enum

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,7 +31,8 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _enqueue() {
-    queue.enqueueRequest(method: 'GET', url: '/delay/1', priority: enqueued++);
+    queue.enqueueRequest(
+        method: HttpMethod.get, url: '/delay/1', priority: enqueued++);
   }
 
   @override

--- a/lib/dio_queue.dart
+++ b/lib/dio_queue.dart
@@ -1,4 +1,4 @@
-/// A Calculator.
+/// Example library containing a trivial [Calculator].
 class Calculator {
   /// Returns [value] plus 1.
   int addOne(int value) => value + 1;

--- a/lib/flutter_dio_queue.dart
+++ b/lib/flutter_dio_queue.dart
@@ -1,3 +1,4 @@
+/// Flutter bindings and exports for the dio queue package.
 library flutter_dio_queue;
 
 export 'src/queue_client.dart';
@@ -9,3 +10,4 @@ export 'src/hive_storage.dart';
 export 'src/logger.dart';
 export 'src/metrics.dart';
 export 'src/queue_interceptor.dart';
+export 'src/http_method.dart';

--- a/lib/src/backoff.dart
+++ b/lib/src/backoff.dart
@@ -1,3 +1,4 @@
+/// Utilities for computing retry backoff delays.
 import 'dart:math';
 
 import 'queue_config.dart';

--- a/lib/src/connectivity_watcher.dart
+++ b/lib/src/connectivity_watcher.dart
@@ -1,3 +1,4 @@
+/// Monitors network connectivity changes and exposes an online/offline stream.
 import 'dart:async';
 
 import 'package:connectivity_plus/connectivity_plus.dart';

--- a/lib/src/dio_extensions.dart
+++ b/lib/src/dio_extensions.dart
@@ -1,6 +1,8 @@
+/// Convenience extensions for converting Dio requests into queue jobs.
 import 'package:dio/dio.dart';
 
 import 'queue_job.dart';
+import 'http_method.dart';
 
 extension RequestOptionsQueue on RequestOptions {
   /// Creates a [QueueJob] from these options.
@@ -13,7 +15,7 @@ extension RequestOptionsQueue on RequestOptions {
   }) {
     return QueueJob(
       id: id,
-      method: method,
+      method: HttpMethodX.fromString(method),
       url: path,
       headers: headers.map((k, v) => MapEntry(k, v)),
       body: data,

--- a/lib/src/hive_storage.dart
+++ b/lib/src/hive_storage.dart
@@ -1,3 +1,4 @@
+/// Persistent queue storage backed by Hive.
 import 'package:hive/hive.dart';
 
 import 'queue_job.dart';

--- a/lib/src/http_method.dart
+++ b/lib/src/http_method.dart
@@ -1,0 +1,17 @@
+/// Supported HTTP methods for queued requests.
+enum HttpMethod {
+  get,
+  post,
+  put,
+  delete,
+  head,
+  patch,
+  options,
+}
+
+extension HttpMethodX on HttpMethod {
+  String get value => name.toUpperCase();
+
+  static HttpMethod fromString(String method) =>
+      HttpMethod.values.byName(method.toLowerCase());
+}

--- a/lib/src/memory_storage.dart
+++ b/lib/src/memory_storage.dart
@@ -1,3 +1,4 @@
+/// In-memory implementation of the queue storage interface.
 import 'dart:async';
 
 import 'queue_job.dart';

--- a/lib/src/queue_client.dart
+++ b/lib/src/queue_client.dart
@@ -1,3 +1,4 @@
+/// High-level API for interacting with the request queue.
 import 'dart:async';
 import 'package:dio/dio.dart';
 
@@ -10,6 +11,7 @@ import 'queue_job.dart';
 import 'queue_storage.dart';
 import 'memory_storage.dart';
 import 'scheduler.dart';
+import 'http_method.dart';
 
 /// Public facade for the queue system.
 class FlutterDioQueue {
@@ -56,7 +58,7 @@ class FlutterDioQueue {
 
   /// Convenience builder to enqueue a request without manual [QueueJob].
   String enqueueRequest({
-    required String method,
+    required HttpMethod method,
     required String url,
     Map<String, dynamic>? headers,
     dynamic data,

--- a/lib/src/queue_config.dart
+++ b/lib/src/queue_config.dart
@@ -1,3 +1,4 @@
+/// Shared configuration models for the queue and retry behaviour.
 import 'package:dio/dio.dart';
 
 /// Signature deciding whether a request should retry.

--- a/lib/src/queue_event.dart
+++ b/lib/src/queue_event.dart
@@ -1,3 +1,4 @@
+/// Events describing changes to queue job state.
 import 'queue_job.dart';
 
 /// Event emitted for job state changes.

--- a/lib/src/queue_interceptor.dart
+++ b/lib/src/queue_interceptor.dart
@@ -1,6 +1,8 @@
+/// Interceptor that diverts selected requests into the queue for later execution.
 import 'package:dio/dio.dart';
 
 import 'queue_client.dart';
+import 'http_method.dart';
 
 typedef QueuePredicate = bool Function(RequestOptions options);
 
@@ -19,7 +21,7 @@ class QueueInterceptor extends Interceptor {
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     if (predicate(options)) {
       queue.enqueueRequest(
-        method: options.method,
+        method: HttpMethodX.fromString(options.method),
         url: options.path,
         headers: Map<String, dynamic>.from(options.headers),
         data: options.data,

--- a/lib/src/queue_job.dart
+++ b/lib/src/queue_job.dart
@@ -1,11 +1,13 @@
+/// Data model representing a request scheduled for later execution.
 import 'dart:convert';
 
 import 'queue_config.dart';
+import 'http_method.dart';
 
 /// Model representing an enqueued request.
 class QueueJob {
   final String id;
-  final String method;
+  final HttpMethod method;
   final String url;
   final Map<String, dynamic>? headers;
   final dynamic body;
@@ -45,7 +47,7 @@ class QueueJob {
   String get fingerprint {
     if (idempotencyKey != null) return idempotencyKey!;
     final payload = jsonEncode({
-      'm': method,
+      'm': method.value,
       'u': url,
       'h': headers,
       'b': body,
@@ -56,7 +58,7 @@ class QueueJob {
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'method': method,
+        'method': method.value,
         'url': url,
         'headers': headers,
         'body': body,
@@ -75,7 +77,7 @@ class QueueJob {
 
   static QueueJob fromJson(Map<String, dynamic> json) => QueueJob(
         id: json['id'] as String,
-        method: json['method'] as String,
+        method: HttpMethodX.fromString(json['method'] as String),
         url: json['url'] as String,
         headers: (json['headers'] as Map?)?.cast<String, dynamic>(),
         body: json['body'],

--- a/lib/src/queue_storage.dart
+++ b/lib/src/queue_storage.dart
@@ -1,3 +1,4 @@
+/// Interface describing storage for persisted queue jobs.
 import 'queue_job.dart';
 
 /// Storage backend for persisting jobs.

--- a/lib/src/rate_limiter.dart
+++ b/lib/src/rate_limiter.dart
@@ -1,3 +1,4 @@
+/// Token bucket based rate limiter for throttling job execution.
 import 'dart:async';
 import 'dart:math';
 

--- a/lib/src/scheduler.dart
+++ b/lib/src/scheduler.dart
@@ -1,3 +1,4 @@
+/// Core scheduler responsible for executing queued jobs.
 import 'dart:async';
 import 'dart:math';
 
@@ -12,6 +13,7 @@ import 'queue_event.dart';
 import 'queue_job.dart';
 import 'queue_storage.dart';
 import 'rate_limiter.dart';
+import 'http_method.dart';
 
 class Scheduler {
   final Dio dio;
@@ -126,7 +128,7 @@ class Scheduler {
     while (true) {
       await _rateLimiter.take();
       try {
-        final opts = Options(method: job.method, headers: job.headers);
+        final opts = Options(method: job.method.value, headers: job.headers);
         final res = await dio.request(
           job.url,
           data: job.body,

--- a/test/integration_dio_test.dart
+++ b/test/integration_dio_test.dart
@@ -20,7 +20,7 @@ void main() {
       config: QueueConfig(retry: RetryPolicy(maxAttempts: 3, baseDelay: const Duration(milliseconds: 10), jitter: 0)),
     );
     final future = queue.events.firstWhere((e) => e.job.state == JobState.succeeded);
-    queue.enqueueRequest(method: 'GET', url: '/');
+    queue.enqueueRequest(method: HttpMethod.get, url: '/');
     final event = await future;
     expect(event.job.attempts, 2);
     expect(attempts, 2);

--- a/test/queue_client_test.dart
+++ b/test/queue_client_test.dart
@@ -12,7 +12,7 @@ void main() {
       });
     final queue = FlutterDioQueue(dio: dio);
     final future = queue.events.firstWhere((e) => e.job.state == JobState.succeeded);
-    queue.enqueueRequest(method: 'GET', url: '/');
+    queue.enqueueRequest(method: HttpMethod.get, url: '/');
     final event = await future;
     expect(event.job.state, JobState.succeeded);
   });

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -16,8 +16,8 @@ void main() {
     queue.events
         .where((e) => e.job.state == JobState.succeeded)
         .listen((e) => completed.add(e.job.url));
-    queue.enqueueRequest(method: 'GET', url: 'a', priority: 0);
-    queue.enqueueRequest(method: 'GET', url: 'b', priority: 5);
+    queue.enqueueRequest(method: HttpMethod.get, url: 'a', priority: 0);
+    queue.enqueueRequest(method: HttpMethod.get, url: 'b', priority: 5);
     await Future.delayed(const Duration(milliseconds: 100));
     expect(completed, ['b', 'a']);
   });
@@ -39,9 +39,9 @@ void main() {
         running--;
       }
     });
-    queue.enqueueRequest(method: 'GET', url: '1');
-    queue.enqueueRequest(method: 'GET', url: '2');
-    queue.enqueueRequest(method: 'GET', url: '3');
+    queue.enqueueRequest(method: HttpMethod.get, url: '1');
+    queue.enqueueRequest(method: HttpMethod.get, url: '2');
+    queue.enqueueRequest(method: HttpMethod.get, url: '3');
     await Future.delayed(const Duration(milliseconds: 200));
     expect(max, lessThanOrEqualTo(2));
   });

--- a/test/storage_test.dart
+++ b/test/storage_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('memory storage basics', () async {
     final storage = MemoryQueueStorage();
     await storage.init();
-    final job = QueueJob(id: '1', method: 'GET', url: '/');
+    final job = QueueJob(id: '1', method: HttpMethod.get, url: '/');
     await storage.upsert(job);
     expect((await storage.getById('1'))?.id, '1');
     await storage.delete('1');


### PR DESCRIPTION
## Summary
- add HttpMethod enum covering common HTTP verbs
- refactor queue job and API to use strongly typed HttpMethod
- document all library files with top-level comments

## Testing
- `dart format lib example test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9335a9690832889a49c83664d5968