### PR TITLE
Add request queue wrapper and documentation for dio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## 0.0.1
 
-* TODO: Describe initial release.
+* Initial release with a simple sequential request queue for Dio.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,42 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# dio_queue
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
-
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
-
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+A lightweight request queue wrapper around the [Dio](https://pub.dev/packages/dio) HTTP client. The queue executes requests sequentially in the order they are added, helping to avoid rate limits and ensuring that only one request is active at a time.
 
 ## Features
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+- Serializes requests so only one runs at once.
+- Works with any existing `Dio` instance.
+- Returns the normal `Dio` `Response` objects.
 
 ## Getting started
 
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
+Add the package and its dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  dio: ^5.4.0
+  dio_queue: ^0.0.1
+```
+
+Run `flutter pub get` to install the packages.
 
 ## Usage
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
-
 ```dart
-const like = 'sample';
+import 'package:dio/dio.dart';
+import 'package:dio_queue/dio_queue.dart';
+
+final queue = DioQueue(Dio());
+
+Future<void> makeRequests() async {
+  final first = queue.enqueue((dio) => dio.get('/first'));
+  final second = queue.enqueue((dio) => dio.get('/second'));
+
+  final results = await Future.wait([first, second]);
+  print(results.first.data);
+}
 ```
 
 ## Additional information
 
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+The project is maintained on GitHub. Issues and pull requests are welcome. If you encounter a problem or have an improvement, please open an issue.

--- a/lib/dio_queue.dart
+++ b/lib/dio_queue.dart
@@ -1,5 +1,61 @@
-/// A Calculator.
-class Calculator {
-  /// Returns [value] plus 1.
-  int addOne(int value) => value + 1;
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:dio/dio.dart';
+
+/// Sequential request queue for the [Dio] HTTP client.
+///
+/// `DioQueue` wraps an existing [Dio] instance and ensures that enqueued
+/// requests are executed one at a time in the order they were added. This is
+/// useful when working with APIs that enforce strict rate limits or when you
+/// need to serialize writes.
+///
+/// ```dart
+/// final queue = DioQueue(Dio());
+/// final first = queue.enqueue((dio) => dio.get('/first'));
+/// final second = queue.enqueue((dio) => dio.get('/second'));
+///
+/// final responses = await Future.wait([first, second]);
+/// print(responses.first.data);
+/// ```
+class DioQueue {
+  /// Creates a queue that wraps the provided [dio] client.
+  DioQueue(this._dio);
+
+  final Dio _dio;
+  final Queue<_QueuedRequest<dynamic>> _queue = Queue<_QueuedRequest<dynamic>>();
+  bool _running = false;
+
+  /// Enqueues a [request] for sequential execution and returns its response.
+  ///
+  /// The [request] callback receives the wrapped [Dio] instance and should
+  /// return a `Future` produced by calling one of the `Dio` request methods.
+  /// Requests are executed in first-in, first-out order, and only one request
+  /// runs at a time.
+  Future<Response<T>> enqueue<T>(Future<Response<T>> Function(Dio dio) request) {
+    final completer = Completer<Response<T>>();
+    _queue.add(_QueuedRequest<T>(request, completer));
+    _process();
+    return completer.future;
+  }
+
+  void _process() {
+    if (_running || _queue.isEmpty) return;
+    _running = true;
+    final job = _queue.removeFirst();
+    job.request(_dio).then(job.completer.complete).catchError(
+      job.completer.completeError,
+    ).whenComplete(() {
+      _running = false;
+      _process();
+    });
+  }
+}
+
+/// Internal representation of a queued [request].
+class _QueuedRequest<T> {
+  _QueuedRequest(this.request, this.completer);
+
+  final Future<Response<T>> Function(Dio dio) request;
+  final Completer<Response<T>> completer;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dio_queue
-description: "A new Flutter project."
+description: A sequential request queue for the Dio HTTP client.
 version: 0.0.1
 homepage:
 
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  dio: ^5.4.0
 
 dev_dependencies:
   flutter_test:

--- a/test/dio_queue_test.dart
+++ b/test/dio_queue_test.dart
@@ -1,12 +1,41 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dio_queue/dio_queue.dart';
 
 void main() {
-  test('adds one to input values', () {
-    final calculator = Calculator();
-    expect(calculator.addOne(2), 3);
-    expect(calculator.addOne(-7), -6);
-    expect(calculator.addOne(0), 1);
+  test('processes requests one at a time', () async {
+    final adapter = _TrackingAdapter();
+    final dio = Dio()..httpClientAdapter = adapter;
+    final queue = DioQueue(dio);
+
+    final futures = [
+      queue.enqueue((d) => d.get('/1')),
+      queue.enqueue((d) => d.get('/2')),
+      queue.enqueue((d) => d.get('/3')),
+    ];
+
+    await Future.wait(futures);
+    expect(adapter.maxConcurrent, 1);
   });
+}
+
+class _TrackingAdapter extends HttpClientAdapter {
+  int _current = 0;
+  int maxConcurrent = 0;
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, Stream<List<int>>? requestStream, Future? cancelFuture) async {
+    _current++;
+    maxConcurrent = max(maxConcurrent, _current);
+    await Future.delayed(const Duration(milliseconds: 20));
+    _current--;
+    return ResponseBody.fromString('ok', 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
 }


### PR DESCRIPTION
## Summary
- implement DioQueue class for sequential request execution
- document the package and add usage instructions
- add dependency on dio and initial changelog entry

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9846b5bac8328b6909602fd2e17c8