### PR TITLE
fix: import JobState type in storage classes

### DIFF
--- a/lib/src/hive_storage.dart
+++ b/lib/src/hive_storage.dart
@@ -1,6 +1,7 @@
 /// Persistent queue storage backed by Hive.
 import 'package:hive/hive.dart';
 
+import 'queue_config.dart';
 import 'queue_job.dart';
 import 'queue_storage.dart';
 

--- a/lib/src/memory_storage.dart
+++ b/lib/src/memory_storage.dart
@@ -1,6 +1,7 @@
 /// In-memory implementation of the queue storage interface.
 import 'dart:async';
 
+import 'queue_config.dart';
 import 'queue_job.dart';
 import 'queue_storage.dart';
 

--- a/lib/src/queue_storage.dart
+++ b/lib/src/queue_storage.dart
@@ -1,4 +1,5 @@
 /// Interface describing storage for persisted queue jobs.
+import 'queue_config.dart';
 import 'queue_job.dart';
 
 /// Storage backend for persisting jobs.


### PR DESCRIPTION
## Summary
- import `JobState` enum into storage classes to resolve missing type errors

## Testing
- `dart format lib/src/queue_storage.dart lib/src/memory_storage.dart lib/src/hive_storage.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3c8ac9508328af7754b6255b585b