### PR TITLE
Handle FormData uploads

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,33 @@
+# File Uploads
+
+The queue works with Dio's `FormData` to support multipart file uploads on
+Android, iOS and Web. Construct a `FormData` instance and pass it directly to
+`enqueueRequest` without JSON encoding.
+
+```dart
+final queue = FlutterDioQueue(dio: Dio());
+
+final file = File('path/to/pic.jpg');
+final form = FormData.fromMap({
+  'file': await MultipartFile.fromFile(file.path, filename: 'pic.jpg'),
+});
+
+queue.enqueueRequest(
+  method: HttpMethod.post,
+  url: '/upload',
+  data: form,
+);
+```
+
+For Web or in-memory data, use `MultipartFile.fromBytes`:
+
+```dart
+final form = FormData.fromMap({
+  'file': MultipartFile.fromBytes(bytes, filename: 'pic.jpg'),
+});
+```
+
+The queue sets `multipart/form-data` automatically when a `FormData` body is
+detected. If the referenced file does not exist, `MultipartFile.fromFile` will
+throw a `FileSystemException`.
+

--- a/lib/src/scheduler.dart
+++ b/lib/src/scheduler.dart
@@ -147,7 +147,13 @@ class Scheduler {
     while (true) {
       await _rateLimiter.take();
       try {
-        final opts = Options(method: job.method.value, headers: job.headers);
+        final opts = Options(
+          method: job.method.value,
+          headers: job.headers,
+          contentType: job.body is FormData
+              ? Headers.multipartFormDataContentType
+              : null,
+        );
         final res = await dio.request(
           job.url,
           data: job.body,

--- a/test/form_data_upload_test.dart
+++ b/test/form_data_upload_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+import 'dart:convert';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dio_queue/flutter_dio_queue.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  test('uploads file from disk', () async {
+    final temp = await File('${Directory.systemTemp.path}/upload.txt').create();
+    await temp.writeAsString('hello');
+
+    late RequestOptions captured;
+    final dio = Dio()
+      ..httpClientAdapter = TestAdapter((req) async {
+        captured = req;
+        return ResponseBody.fromString('ok', 200);
+      });
+
+    final queue = FlutterDioQueue(dio: dio);
+    final formData = FormData.fromMap({
+      'file': await MultipartFile.fromFile(temp.path, filename: 'upload.txt'),
+    });
+
+    final future = queue.events.firstWhere((e) => e.job.state == JobState.succeeded);
+    queue.enqueueRequest(method: HttpMethod.post, url: '/upload', data: formData);
+    final event = await future;
+
+    expect(event.response?.statusCode, 200);
+    expect(captured.data, isA<FormData>());
+    expect(captured.contentType, contains('multipart/form-data'));
+
+    await temp.delete();
+  });
+
+  test('uploads bytes from memory', () async {
+    late RequestOptions captured;
+    final dio = Dio()
+      ..httpClientAdapter = TestAdapter((req) async {
+        captured = req;
+        return ResponseBody.fromString('ok', 200);
+      });
+
+    final queue = FlutterDioQueue(dio: dio);
+    final bytes = utf8.encode('hi');
+    final formData = FormData.fromMap({
+      'file': MultipartFile.fromBytes(bytes, filename: 'bytes.txt'),
+    });
+
+    final future = queue.events.firstWhere((e) => e.job.state == JobState.succeeded);
+    queue.enqueueRequest(method: HttpMethod.post, url: '/upload', data: formData);
+    final event = await future;
+
+    expect(event.response?.statusCode, 200);
+    expect(captured.data, isA<FormData>());
+    expect(captured.contentType, contains('multipart/form-data'));
+  });
+
+  test('throws when file is missing', () async {
+    await expectLater(
+      () async => MultipartFile.fromFile('does_not_exist.txt'),
+      throwsA(isA<FileSystemException>()),
+    );
+  });
+}
+


### PR DESCRIPTION
## Summary
- avoid JSON encoding FormData in job fingerprints and serialization
- send FormData with multipart content type
- add tests and documentation for file uploads

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb404dc9908328930c421427a764ef