### PR TITLE
Fix storage init race and add hive tests

### DIFF
--- a/lib/src/hive_storage.dart
+++ b/lib/src/hive_storage.dart
@@ -11,34 +11,40 @@ class HiveQueueStorage implements QueueStorage {
   final String boxName;
 
   Box<Map>? _box;
+  Future<void>? _init;
 
   /// Creates a Hive-based storage using [boxName].
   HiveQueueStorage({required this.boxName});
 
   @override
   /// Opens the Hive box.
-  Future<void> init() async {
-    _box = await Hive.openBox<Map>(boxName);
+  Future<void> init() {
+    return _init ??= Hive.openBox<Map>(boxName).then((box) {
+      _box = box;
+    });
   }
 
-  Box<Map> get _ensureBox {
+  Future<Box<Map>> _getBox() async {
+    await init();
     final box = _box;
     if (box == null) {
       throw StateError('Storage not initialized');
     }
     return box;
-    }
+  }
 
   @override
   /// Stores or replaces [job] in the box.
   Future<void> upsert(QueueJob job) async {
-    await _ensureBox.put(job.id, job.toJson());
+    final box = await _getBox();
+    await box.put(job.id, job.toJson());
   }
 
   @override
   /// Retrieves a job by [id] or returns `null`.
   Future<QueueJob?> getById(String id) async {
-    final map = _ensureBox.get(id);
+    final box = await _getBox();
+    final map = box.get(id);
     if (map == null) return null;
     return QueueJob.fromJson(Map<String, dynamic>.from(map));
   }
@@ -46,7 +52,8 @@ class HiveQueueStorage implements QueueStorage {
   @override
   /// Returns all stored jobs, optionally filtered by [state].
   Future<List<QueueJob>> getAll({JobState? state}) async {
-    return _ensureBox.values
+    final box = await _getBox();
+    return box.values
         .map((m) => QueueJob.fromJson(Map<String, dynamic>.from(m)))
         .where((j) => state == null || j.state == state)
         .toList();
@@ -54,9 +61,15 @@ class HiveQueueStorage implements QueueStorage {
 
   @override
   /// Deletes the job identified by [id].
-  Future<void> delete(String id) async => _ensureBox.delete(id);
+  Future<void> delete(String id) async {
+    final box = await _getBox();
+    await box.delete(id);
+  }
 
   @override
   /// Clears all jobs from storage.
-  Future<void> clear() async => _ensureBox.clear();
+  Future<void> clear() async {
+    final box = await _getBox();
+    await box.clear();
+  }
 }

--- a/lib/src/memory_storage.dart
+++ b/lib/src/memory_storage.dart
@@ -8,24 +8,32 @@ import 'queue_storage.dart';
 /// In-memory storage used by default.
 class MemoryQueueStorage implements QueueStorage {
   final Map<String, QueueJob> _jobs = {};
+  Future<void>? _init;
 
   @override
   /// No-op initialisation for in-memory storage.
-  Future<void> init() async {}
+  Future<void> init() {
+    return _init ??= Future.value();
+  }
 
   @override
   /// Stores or replaces [job] in memory.
   Future<void> upsert(QueueJob job) async {
+    await init();
     _jobs[job.id] = job;
   }
 
   @override
   /// Retrieves a job by [id].
-  Future<QueueJob?> getById(String id) async => _jobs[id];
+  Future<QueueJob?> getById(String id) async {
+    await init();
+    return _jobs[id];
+  }
 
   @override
   /// Returns all jobs, optionally filtered by [state].
   Future<List<QueueJob>> getAll({JobState? state}) async {
+    await init();
     var values = _jobs.values.toList();
     if (state != null) {
       values = values.where((j) => j.state == state).toList();
@@ -36,10 +44,14 @@ class MemoryQueueStorage implements QueueStorage {
   @override
   /// Removes the job identified by [id].
   Future<void> delete(String id) async {
+    await init();
     _jobs.remove(id);
   }
 
   @override
   /// Clears all stored jobs.
-  Future<void> clear() async => _jobs.clear();
+  Future<void> clear() async {
+    await init();
+    _jobs.clear();
+  }
 }

--- a/lib/src/queue_client.dart
+++ b/lib/src/queue_client.dart
@@ -45,7 +45,7 @@ class FlutterDioQueue {
           connectivity: connectivity,
           logger: logger,
         ) {
-    this.storage.init();
+    unawaited(this.storage.init());
   }
 
   /// Stream of job state change events.

--- a/test/hive_storage_initialization_test.dart
+++ b/test/hive_storage_initialization_test.dart
@@ -1,0 +1,38 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dio_queue/flutter_dio_queue.dart';
+import 'package:hive_test/hive_test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  setUp(() async {
+    await setUpTestHive();
+  });
+
+  tearDown(() async {
+    await tearDownTestHive();
+  });
+
+  test('hive storage waits for initialization before use', () async {
+    final dio = Dio()
+      ..httpClientAdapter = TestAdapter((req) async {
+        return ResponseBody.fromString('ok', 200);
+      });
+    final storage = HiveQueueStorage(boxName: 'queue');
+    final queue = FlutterDioQueue(dio: dio, storage: storage);
+
+    final eventFuture =
+        queue.events.firstWhere((e) => e.job.state == JobState.succeeded);
+    queue.enqueueRequest(method: HttpMethod.get, url: '/');
+    final event = await eventFuture;
+    expect(event.job.state, JobState.succeeded);
+  });
+
+  test('init is idempotent', () async {
+    final storage = HiveQueueStorage(boxName: 'queue');
+    await Future.wait([storage.init(), storage.init(), storage.init()]);
+    await storage.upsert(QueueJob(id: '1', method: HttpMethod.get, url: '/'));
+    expect((await storage.getById('1'))?.id, '1');
+  });
+}


### PR DESCRIPTION
## Summary
- ensure storage backends are awaitable and init only once
- prevent queue from using storage before ready
- cover hive initialization with tests

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc5f8183c832895008516e8ede382