### PR TITLE
Handle FormData bodies in job serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Allow `QueueJob.toJson` to handle `FormData` bodies by omitting them instead of throwing.
+
 ## 0.1.1
 
 - Avoid serializing `FormData` bodies and skip persistence when present.

--- a/lib/src/queue_job.dart
+++ b/lib/src/queue_job.dart
@@ -123,15 +123,13 @@ class QueueJob {
 
   /// Serialises this job into a JSON compatible map.
   Map<String, dynamic> toJson() {
-    if (body is FormData) {
-      throw UnsupportedError('FormData bodies cannot be serialized');
-    }
     return {
       'id': id,
       'method': method.value,
       'url': url,
       'headers': headers,
-      'body': body,
+      // FormData cannot be JSON encoded; omit from serialization.
+      'body': body is FormData ? null : body,
       'query': query,
       'idempotencyKey': idempotencyKey,
       'tags': tags.toList(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dio_queue
 description: A robust request queue layer on top of Dio.
-version: 0.1.1
+version: 0.1.2
 publish_to: none
 
 environment:

--- a/test/queue_job_serialization_test.dart
+++ b/test/queue_job_serialization_test.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dio_queue/flutter_dio_queue.dart';
+
+void main() {
+  test('toJson omits FormData bodies', () {
+    final job = QueueJob(
+      id: '1',
+      method: HttpMethod.post,
+      url: '/upload',
+      body: FormData.fromMap({'key': 'value'}),
+    );
+    final json = job.toJson();
+    expect(json['body'], isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- avoid throwing when serializing FormData bodies
- cover FormData serialization with a new test
- bump version to 0.1.2

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update >/tmp/apt_update.log && tail -n 20 /tmp/apt_update.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbde0a1c30832896432d111ef2b525