### PR TITLE
feat: add isLastRequest parameter to QueueJob

### DIFF
--- a/lib/src/dio_extensions.dart
+++ b/lib/src/dio_extensions.dart
@@ -26,6 +26,9 @@ extension RequestOptionsQueue on RequestOptions {
 
     /// How long the request is allowed to run.
     Duration? timeout,
+
+    /// Whether this should be marked as the last request.
+    bool isLastRequest = false,
   }) {
     return QueueJob(
       id: id,
@@ -38,6 +41,7 @@ extension RequestOptionsQueue on RequestOptions {
       tags: tags,
       priority: priority,
       timeout: timeout,
+      isLastRequest: isLastRequest,
     );
   }
 }

--- a/lib/src/queue_client.dart
+++ b/lib/src/queue_client.dart
@@ -98,6 +98,9 @@ class FlutterDioQueue {
 
     /// Timeout for the request.
     Duration? timeout,
+
+    /// Whether this job is the last request in a sequence.
+    bool isLastRequest = false,
   }) {
     final job = QueueJob(
       id: _randomId(),
@@ -110,6 +113,7 @@ class FlutterDioQueue {
       tags: tags,
       priority: priority,
       timeout: timeout,
+      isLastRequest: isLastRequest,
     );
     _scheduler.enqueue(job);
     return job.id;

--- a/lib/src/queue_job.dart
+++ b/lib/src/queue_job.dart
@@ -56,6 +56,9 @@ class QueueJob {
   /// Last error produced by the job, if any.
   Object? lastError;
 
+  /// Whether this job represents the last request in a sequence.
+  final bool isLastRequest;
+
   /// Creates a new [QueueJob].
   QueueJob({
     /// Identifier for this job.
@@ -105,6 +108,9 @@ class QueueJob {
 
     /// Last error produced.
     this.lastError,
+
+    /// Indicates if this is the last request in a batch.
+    this.isLastRequest = false,
   }) : enqueuedAt = enqueuedAt ?? DateTime.now();
 
   /// Fingerprint used for deduplication.
@@ -143,6 +149,7 @@ class QueueJob {
       'startedAt': startedAt?.toIso8601String(),
       'finishedAt': finishedAt?.toIso8601String(),
       'lastError': lastError?.toString(),
+      'isLastRequest': isLastRequest,
     };
   }
 
@@ -170,5 +177,6 @@ class QueueJob {
             ? DateTime.parse(json['finishedAt'] as String)
             : null,
         lastError: json['lastError'],
+        isLastRequest: json['isLastRequest'] as bool? ?? false,
       );
 }

--- a/test/queue_job_test.dart
+++ b/test/queue_job_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dio_queue/flutter_dio_queue.dart';
+
+void main() {
+  test('isLastRequest serialises and deserialises correctly', () {
+    final job = QueueJob(
+      id: '1',
+      method: HttpMethod.get,
+      url: '/',
+      isLastRequest: true,
+    );
+    final json = job.toJson();
+    expect(json['isLastRequest'], isTrue);
+    final restored = QueueJob.fromJson(json);
+    expect(restored.isLastRequest, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- allow queue jobs to indicate the final request via `isLastRequest`
- expose `isLastRequest` through client and request option helpers
- cover serialization of new flag with unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdfb7559483288f7988334038c089