### PR TITLE
feat(queue): add autoStart flag and manual start control

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ final queue = FlutterDioQueue(
   config: QueueConfig(
     maxConcurrent: 3,
     policy: QueuePolicy.fifo,
+    autoStart: true,
     retry: RetryPolicy(
       maxAttempts: 4,
       baseDelay: const Duration(milliseconds: 400),
@@ -64,6 +65,14 @@ queue.events.listen((e) {
     debugPrint('Response data: ${e.response!.data}');
   }
 });
+
+// When `autoStart` is set to `false`, explicitly start processing:
+// queue.start();
+
+// You can also pause/resume or wait for completion with:
+// queue.pause();
+// queue.resume();
+// await queue.drain();
 ```
 
 ## Interceptor

--- a/lib/src/queue_client.dart
+++ b/lib/src/queue_client.dart
@@ -63,11 +63,17 @@ class FlutterDioQueue {
   /// Cancels all jobs tagged with [tag].
   Future<void> cancelByTag(String tag) => _scheduler.cancelByTag(tag);
 
+  /// Starts processing of queued jobs when [QueueConfig.autoStart] is `false`.
+  void start() => _scheduler.start();
+
   /// Pauses scheduling of new jobs; running jobs continue.
   void pause() => _scheduler.pause();
 
   /// Resumes scheduling after a pause.
   void resume() => _scheduler.resume();
+
+  /// Waits for the queue to become idle (no queued or running jobs).
+  Future<void> drain() => _scheduler.drain();
 
   /// Convenience builder to enqueue a request without manually constructing a
   /// [QueueJob].

--- a/lib/src/queue_config.dart
+++ b/lib/src/queue_config.dart
@@ -79,6 +79,13 @@ class QueueConfig {
   /// Optional time-to-live for completed jobs.
   final Duration? jobTTL;
 
+  /// Whether the queue should begin processing immediately when jobs
+  /// are enqueued.
+  ///
+  /// When `false`, jobs will remain in the pending state until
+  /// [FlutterDioQueue.start] is called.
+  final bool autoStart;
+
   /// Creates a new [QueueConfig] with optional overrides.
   const QueueConfig({
     this.maxConcurrent = 1,
@@ -88,5 +95,6 @@ class QueueConfig {
     this.deduplicate = true,
     this.persist = false,
     this.jobTTL,
+    this.autoStart = true,
   });
 }


### PR DESCRIPTION
## Summary
- add `autoStart` option to `QueueConfig`
- expose `start()` and `drain()` on `FlutterDioQueue` to manually control processing
- update scheduler to respect manual start and provide `drain()`
- document new controls
- test LIFO ordering when auto start is disabled

## Testing
- `dart format lib/src/queue_config.dart lib/src/scheduler.dart lib/src/queue_client.dart test/scheduler_test.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe062f0288328bf6f7f293fdf103f